### PR TITLE
Create requirements_m1.txt for Apple M1

### DIFF
--- a/requirements_m1.txt
+++ b/requirements_m1.txt
@@ -1,0 +1,10 @@
+grpcio==1.49.0
+numpy==1.23.3
+Pillow==9.2.0
+protobuf==3.19.0
+tensorflow-addons==0.17.1
+tensorflow-macos==2.10.0
+tensorflow-metal==0.6.0
+tqdm==4.64.1
+ftfy==6.1.1
+regex==2022.9.13


### PR DESCRIPTION
Tested with python 3.10 on macOS 12.6