### PR TITLE
fix random seeding of latent

### DIFF
--- a/stable_diffusion_tf/diffusion_model.py
+++ b/stable_diffusion_tf/diffusion_model.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 from tensorflow import keras
 import tensorflow_addons as tfa
 
-from .layers import PaddedConv2D, apply_seq, td_dot, GEGLU
+from .layers import PaddedConv2D, apply_seq, GEGLU
 
 
 class ResBlock(keras.layers.Layer):
@@ -63,9 +63,9 @@ class CrossAttention(keras.layers.Layer):
         k = keras.layers.Permute((2, 3, 1))(k)  # (bs, num_heads, head_size, time)
         v = keras.layers.Permute((2, 1, 3))(v)  # (bs, num_heads, time, head_size)
 
-        score = td_dot(q, k) * self.scale
+        score = tf.matmul(q, k) * self.scale
         weights = keras.activations.softmax(score)  # (bs, num_heads, time, time)
-        attention = td_dot(weights, v)
+        attention = tf.matmul(weights, v)
         attention = keras.layers.Permute((2, 1, 3))(
             attention
         )  # (bs, time, num_heads, head_size)

--- a/stable_diffusion_tf/layers.py
+++ b/stable_diffusion_tf/layers.py
@@ -41,9 +41,3 @@ def apply_seq(x, layers):
         x = l(x)
     return x
 
-
-def td_dot(a, b):
-    aa = tf.reshape(a, (-1, a.shape[2], a.shape[3]))
-    bb = tf.reshape(b, (-1, b.shape[2], b.shape[3]))
-    cc = keras.backend.batch_dot(aa, bb)
-    return tf.reshape(cc, (-1, a.shape[1], cc.shape[1], cc.shape[2]))

--- a/stable_diffusion_tf/stable_diffusion.py
+++ b/stable_diffusion_tf/stable_diffusion.py
@@ -130,7 +130,7 @@ class Text2Image:
         n_w = self.img_width // 8
         alphas = [_ALPHAS_CUMPROD[t] for t in timesteps]
         alphas_prev = [1.0] + alphas[:-1]
-        latent = tf.random.normal((batch_size, n_h, n_w, 4), seed=seed)
+        latent = np.random.RandomState(seed).normal(size=(batch_size, n_h, n_w, 4))
         return latent, alphas, alphas_prev
 
 
@@ -157,7 +157,7 @@ def get_models(img_height, img_width, download_weights=True):
     latent = keras.layers.Input((n_h, n_w, 4))
     decoder = Decoder()
     decoder = keras.models.Model(latent, decoder(latent))
-    
+
     if download_weights:
         text_encoder_weights_fpath = keras.utils.get_file(
             origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/text_encoder.h5",


### PR DESCRIPTION
for whatever reason `tf.random.normal` doesn't honour the passed seed...

e.g. consider the following...

```
>>> import numpy as np
>>> import tensorflow as tf
>>> np.sum(tf.random.normal((1,2,3,4), seed=123))
2.359888
>>> np.sum(tf.random.normal((1,2,3,4), seed=123))
-0.19422567
```

this means the current latents generated aren't seeded.
switching to numpy, which is fine here since the initial latents aren't in the TF graph at all, fixes things.
