### PR TITLE
Support --batch parameter

### DIFF
--- a/text2image.py
+++ b/text2image.py
@@ -47,6 +47,10 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--batch", type=int, default=1, help="number of images to generate"
+)
+
+parser.add_argument(
     "--seed",
     type=int,
     help="optionally specify a seed integer for reproducible results",
@@ -71,8 +75,17 @@ img = generator.generate(
     num_steps=args.steps,
     unconditional_guidance_scale=args.scale,
     temperature=1,
-    batch_size=1,
+    batch_size=args.batch,
     seed=args.seed,
 )
-Image.fromarray(img[0]).save(args.output)
-print(f"saved at {args.output}")
+
+if(args.batch > 1):
+    Image.fromarray(img[0]).save(args.output)
+    print(f"saved at {args.output}")
+else:
+    for i in range(args.batch):
+        filename = f"{i}-args.output"
+        Image.fromarray(img[i]).save(args.output)
+    
+    print(f"saved {args.batch} images at {args.output}")
+

--- a/text2image.py
+++ b/text2image.py
@@ -86,12 +86,9 @@ else:
     split_filename = args.output.split(".")
     filename = ''.join(split_filename[0:-1])
     extension = split_filename[-1]
-    def generate_filename(suffix):
-        return f"{filename}-{suffix}.{extension}"
     
     for i in range(args.batch):
-        generated_filename = generate_filename(i + 1)
+        generated_filename = f"{filename}-{i+1}.{extension}"
         Image.fromarray(img[i]).save(generated_filename)
-    
-    print(f"saved {args.batch} images as {generate_filename(f'[{1}, {args.batch}]')}")
+        print(f"saved at {generated_filename}")
 

--- a/text2image.py
+++ b/text2image.py
@@ -79,17 +79,19 @@ img = generator.generate(
     seed=args.seed,
 )
 
-if(args.batch > 1):
-    Image.fromarray(img[0]).save(args.output)
-    print(f"saved at {args.output}")
+if(args.batch <= 1):
+   Image.fromarray(img[0]).save(args.output)
+   print(f"saved at {args.output}")
 else:
     split_filename = args.output.split(".")
-    filename = split_filename[0:-1]
+    filename = ''.join(split_filename[0:-1])
     extension = split_filename[-1]
-    generate_filename = lambda x: f"{filename}-{x}.{extension}"
-    for i in range(args.batch):
-        filename = generate_filename(i + 1)
-        Image.fromarray(img[i]).save(args.output)
+    def generate_filename(suffix):
+        return f"{filename}-{suffix}.{extension}"
     
-    print(f"saved {args.batch} images as {generate_filename(f"1, {args.batch + 1}")}")
+    for i in range(args.batch):
+        generated_filename = generate_filename(i + 1)
+        Image.fromarray(img[i]).save(generated_filename)
+    
+    print(f"saved {args.batch} images as {generate_filename(f'[{1}, {args.batch}]')}")
 

--- a/text2image.py
+++ b/text2image.py
@@ -83,9 +83,13 @@ if(args.batch > 1):
     Image.fromarray(img[0]).save(args.output)
     print(f"saved at {args.output}")
 else:
+    split_filename = args.output.split(".")
+    filename = split_filename[0:-1]
+    extension = split_filename[-1]
+    generate_filename = lambda x: f"{filename}-{x}.{extension}"
     for i in range(args.batch):
-        filename = f"{i}-args.output"
+        filename = generate_filename(i + 1)
         Image.fromarray(img[i]).save(args.output)
     
-    print(f"saved {args.batch} images at {args.output}")
+    print(f"saved {args.batch} images as {generate_filename(f"1, {args.batch + 1}")}")
 


### PR DESCRIPTION
This PR allows passing the `--batch` parameter on the command line so that more than one image can be generated at once. By default, this is set to `1` to replicate existing functionality when this parameter is not provided.

When using batched generation, output is updated to indicate each file that is generated:
```sh
$ python text2image.py --prompt="nothing" --output="test.png" --batch=4

# generator output

saved at test-1.png
saved at test-2.png
saved at test-3.png
saved at test-4.png
```