### PR TITLE
support a phrase/seed per batch element

### DIFF
--- a/text2image.py
+++ b/text2image.py
@@ -59,20 +59,31 @@ parser.add_argument(
     help="Enable mixed precision (fp16 computation)",
 )
 
+parser.add_argument(
+    "--batch-size",
+    type=int,
+    default=1,
+    help="number of prompt/seed images to generate",
+)
+
 args = parser.parse_args()
 
 if args.mp:
     print("Using mixed precision.")
     keras.mixed_precision.set_global_policy("mixed_float16")
 
+prompts = [args.prompt for _ in range(args.batch_size)]
+seeds = [args.seed for _ in range(args.batch_size)]
+
 generator = Text2Image(img_height=args.H, img_width=args.W, jit_compile=False)
-img = generator.generate(
-    args.prompt,
+imgs = generator.generate(
+    prompts,
+    seeds,
     num_steps=args.steps,
     unconditional_guidance_scale=args.scale,
     temperature=1,
-    batch_size=1,
-    seed=args.seed,
 )
-Image.fromarray(img[0]).save(args.output)
-print(f"saved at {args.output}")
+for i, img in enumerate(imgs):
+    fname = f"{i:02d}.{args.output}"
+    Image.fromarray(img).save(fname)
+    print(f"saved at {fname}")


### PR DESCRIPTION
current the seed used seeds the entire batch latent, it's more flexible to instead use a seed per batch element. for the same reason each batch element should allow a different prompt. this allows better iteration on prompt/seed as independent pieces.

( this change also include the latent seeding bug proposed in a prior, now closed, PR )

e.g. sample some seeds for a fixed prompt

```
prompts = ["a blue cabin in the forest next to a lake."] * 10
seeds = list(range(len(prompts)))

imgs = generator.generate(
    prompts,
    seeds,
...
```

![Selection_254](https://user-images.githubusercontent.com/21549/191855135-0ec0b687-5730-42a3-b3a5-5e0c153e5bda.png)

pick `seed=8` as a favourite and iterate on prompt

```
prompts = []
for colour in ['blue', 'dark blue', 'light blue', 'green and blue', 'green']:
    prompts.append(f"a {colour} cabin in the forest next to a lake.")
seeds = [5] * len(prompts)

imgs = generator.generate(
    prompts,
    seeds,
...
```

![Selection_255](https://user-images.githubusercontent.com/21549/191855216-8cfe78b9-8b88-4656-a497-c98c3b5b25fa.png)



