### PR TITLE
Adds an entry to __init__.py for StableDiffusion

### DIFF
--- a/stable_diffusion_tf/__init__.py
+++ b/stable_diffusion_tf/__init__.py
@@ -1,0 +1,1 @@
+from stable_diffusion_tf.stable_diffusion import StableDiffusion


### PR DESCRIPTION
This makes it possible to import:

```
from stable_diffusion_tf import StableDiffusion
```

Also, this is actually required for imports to work if you're working in an alternative directory.