### PR TITLE
Remove extra padding and use asymmetric padding for downsampling

### DIFF
--- a/stable_diffusion_tf/autoencoder_kl.py
+++ b/stable_diffusion_tf/autoencoder_kl.py
@@ -98,15 +98,15 @@ class Encoder(keras.Sequential):
                 PaddedConv2D(128, 3, padding=1 ),
                 ResnetBlock(128,128),
                 ResnetBlock(128, 128),
-                PaddedConv2D(128 , 3 ,  padding=1, stride=2),
+                PaddedConv2D(128 , 3 ,  padding=0, stride=2),
                 
                 ResnetBlock(128,256),
                 ResnetBlock(256, 256),
-                PaddedConv2D(256 , 3 ,  padding=1, stride=2),
+                PaddedConv2D(256 , 3 ,  padding=0, stride=2),
                 
                 ResnetBlock(256,512),
                 ResnetBlock(512, 512),
-                PaddedConv2D(512 , 3 ,  padding=1, stride=2),
+                PaddedConv2D(512 , 3 ,  padding=0, stride=2),
                 
                 ResnetBlock(512,512),
                 ResnetBlock(512, 512),

--- a/stable_diffusion_tf/autoencoder_kl.py
+++ b/stable_diffusion_tf/autoencoder_kl.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 from tensorflow import keras
 import tensorflow_addons as tfa
 
-from .layers import apply_seq, PaddedConv2D, DownsampleConv2D
+from .layers import apply_seq, PaddedConv2D
 
 
 class AttentionBlock(keras.layers.Layer):

--- a/stable_diffusion_tf/autoencoder_kl.py
+++ b/stable_diffusion_tf/autoencoder_kl.py
@@ -98,15 +98,15 @@ class Encoder(keras.Sequential):
                 PaddedConv2D(128, 3, padding=1 ),
                 ResnetBlock(128,128),
                 ResnetBlock(128, 128),
-                DownsampleConv2D(128 , 3 , stride=2),
+                PaddedConv2D(128 , 3 , padding=(0,1), stride=2),
                 
                 ResnetBlock(128,256),
                 ResnetBlock(256, 256),
-                DownsampleConv2D(256 , 3 , stride=2),
+                PaddedConv2D(256 , 3 , padding=(0,1), stride=2),
                 
                 ResnetBlock(256,512),
                 ResnetBlock(512, 512),
-                DownsampleConv2D(512 , 3 , stride=2),
+                PaddedConv2D(512 , 3 , padding=(0,1), stride=2),
                 
                 ResnetBlock(512,512),
                 ResnetBlock(512, 512),

--- a/stable_diffusion_tf/autoencoder_kl.py
+++ b/stable_diffusion_tf/autoencoder_kl.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 from tensorflow import keras
 import tensorflow_addons as tfa
 
-from .layers import apply_seq, PaddedConv2D
+from .layers import apply_seq, PaddedConv2D, DownsampleConv2D
 
 
 class AttentionBlock(keras.layers.Layer):
@@ -98,15 +98,15 @@ class Encoder(keras.Sequential):
                 PaddedConv2D(128, 3, padding=1 ),
                 ResnetBlock(128,128),
                 ResnetBlock(128, 128),
-                PaddedConv2D(128 , 3 ,  padding=0, stride=2),
+                DownsampleConv2D(128 , 3 , stride=2),
                 
                 ResnetBlock(128,256),
                 ResnetBlock(256, 256),
-                PaddedConv2D(256 , 3 ,  padding=0, stride=2),
+                DownsampleConv2D(256 , 3 , stride=2),
                 
                 ResnetBlock(256,512),
                 ResnetBlock(512, 512),
-                PaddedConv2D(512 , 3 ,  padding=0, stride=2),
+                DownsampleConv2D(512 , 3 , stride=2),
                 
                 ResnetBlock(512,512),
                 ResnetBlock(512, 512),

--- a/stable_diffusion_tf/layers.py
+++ b/stable_diffusion_tf/layers.py
@@ -1,20 +1,5 @@
 import tensorflow as tf
 from tensorflow import keras
-
-class DownsampleConv2D(keras.layers.Layer): 
-    #Implemention of Downsample class from ldm/modules/diffusionmodules/model.py
-    #Assume always with_conv, and uses variable channel/kernel/stride instead of hardcoded
-    def __init__(self, channels, kernel_size, stride=1):
-        super().__init__()
-        #Pad right and bottom, as stable diffusion code ((top_pad, bottom_pad), (left_pad, right_pad))
-        self.padding2d = keras.layers.ZeroPadding2D(((0,1), (0,1)))
-        self.conv2d = keras.layers.Conv2D(
-            channels, kernel_size, strides=(stride, stride)
-        )
-
-    def call(self, x):
-        x = self.padding2d(x)
-        return self.conv2d(x)
     
 class PaddedConv2D(keras.layers.Layer):
     def __init__(self, channels, kernel_size, padding=0, stride=1):

--- a/stable_diffusion_tf/layers.py
+++ b/stable_diffusion_tf/layers.py
@@ -1,7 +1,21 @@
 import tensorflow as tf
 from tensorflow import keras
 
+class DownsampleConv2D(keras.layers.Layer): 
+    #Implemention of Downsample class from ldm/modules/diffusionmodules/model.py
+    #Assume always with_conv, and uses variable channel/kernel/stride instead of hardcoded
+    def __init__(self, channels, kernel_size, stride=1):
+        super().__init__()
+        #Pad right and bottom, as stable diffusion code ((top_pad, bottom_pad), (left_pad, right_pad))
+        self.padding2d = keras.layers.ZeroPadding2D(((0,1), (0,1)))
+        self.conv2d = keras.layers.Conv2D(
+            channels, kernel_size, strides=(stride, stride)
+        )
 
+    def call(self, x):
+        x = self.padding2d(x)
+        return self.conv2d(x)
+    
 class PaddedConv2D(keras.layers.Layer):
     def __init__(self, channels, kernel_size, padding=0, stride=1):
         super().__init__()

--- a/stable_diffusion_tf/layers.py
+++ b/stable_diffusion_tf/layers.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 from tensorflow import keras
-    
+
+
 class PaddedConv2D(keras.layers.Layer):
     def __init__(self, channels, kernel_size, padding=0, stride=1):
         super().__init__()


### PR DESCRIPTION
Stable diffusion's first stage encoder doesn't use padding when downsampling (outside of resnetblock). This updates the model to remove the extra padding. It allows encoder to output correct latent now.