### PR TITLE
Inpainting support and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ The easiest way to try it out is to use one of the Colab notebooks:
     ([source](https://twitter.com/fchollet/status/1572004717362028546)).
 - [GPU Colab with Gradio](https://colab.research.google.com/drive/1ANTUur1MF9DKNd5-BTWhbWa7xUBfCWyI)
 
+## Example outputs
+
+The following outputs have been generated using this implementation:
+
+1. _A dog with sunglasses, wearing comfy hat, looking at camera, highly detailed, ultra sharp, cinematic, 100mm lens, 8k resolution._
+
+![a](https://user-images.githubusercontent.com/44222184/194685370-e87970f7-dbf5-4d6d-a9d1-31594cdf751a.png)
+
 ## Installation
 
 ### Install as a python package
@@ -132,14 +140,6 @@ python text2image.py --prompt="An astronaut riding a horse" --output="my_image.p
 ```
 
 Check out the `text2image.py` file for more options, including image size, number of steps, etc.
-
-## Example outputs
-
-The following outputs have been generated using this implementation:
-
-1. _a man in very nice suit, wearing a tie, standing with a dragon, highly detailed, ultra sharp, 100mm lens, cinematic, 8k resolution._
-
-![a](https://user-images.githubusercontent.com/44222184/194581983-f7ce16a5-d558-4d82-bd84-ada466a16e17.png)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stable Diffusion in TensorFlow / Keras
 
-A Keras / Tensorflow implementation of Stable Diffusion.
+A Keras / Tensorflow implementation of Stable Diffusion. 
 
 The weights were ported from the original implementation.
 
@@ -8,9 +8,9 @@ The weights were ported from the original implementation.
 
 The easiest way to try it out is to use one of the Colab notebooks:
 
+
 - [GPU Colab](https://colab.research.google.com/drive/1zVTa4mLeM_w44WaFwl7utTaa6JcaH1zK)
 - [GPU Colab Img2Img](https://colab.research.google.com/drive/1gol0M611zXP6Zpggfri-fG8JDdpMEpsI?usp=sharing)
-- [GPU Colab Inpainting+Text2Image+Image2Image+Mixed Precision](https://colab.research.google.com/drive/1Bf-bNmAdtQhPcYNyC-guu0uTu9MYYfLu)
 - [GPU Colab + Mixed Precision](https://colab.research.google.com/drive/15mQgITh3e9HQMNys0zR8JN4R2vp06d-N)
   - ~10s generation time per image (512x512) on default Colab GPU without drop in quality
     ([source](https://twitter.com/fchollet/status/1571954014845308928))
@@ -19,23 +19,7 @@ The easiest way to try it out is to use one of the Colab notebooks:
     ([source](https://twitter.com/fchollet/status/1572004717362028546)).
 - [GPU Colab with Gradio](https://colab.research.google.com/drive/1ANTUur1MF9DKNd5-BTWhbWa7xUBfCWyI)
 
-## Example outputs
 
-The following outputs have been generated using this implementation:
-
-Input Text: _A dog with sunglasses, wearing comfy hat, looking at camera, highly detailed, ultra sharp, cinematic, 100mm lens, 8k resolution._
-
-# Inpainting
-
-![a](https://user-images.githubusercontent.com/44222184/194685370-e87970f7-dbf5-4d6d-a9d1-31594cdf751a.png)
-
-# Image2Image
-
-![a](https://user-images.githubusercontent.com/44222184/194686889-3d30bd3e-7bfb-4fe4-a6e1-c74bcf5b5944.png)
-
-# Text2Image
-
-![a](https://user-images.githubusercontent.com/44222184/194686712-cb15d191-39b9-4b17-a5c7-2671021ce5e5.png)
 
 ## Installation
 
@@ -65,25 +49,25 @@ Install dependencies using the `requirements.txt` file or the `requirements_m1.t
 pip install -r requirements.txt
 ```
 
-#### Using a virtual environment with _virtualenv_
+#### Using a virtual environment with *virtualenv*
 
-1. Create your virtual environment for `python3`:
+1) Create your virtual environment for `python3`:
 
-   ```bash
-   python3 -m venv venv
-   ```
+    ```bash
+    python3 -m venv venv
+    ```
+   
+2) Activate your virtualenv:
 
-2. Activate your virtualenv:
+    ```bash
+    source venv/bin/activate
+    ```
 
-   ```bash
-   source venv/bin/activate
-   ```
+3) Install dependencies using the `requirements.txt` file or the `requirements_m1.txt` file,:
 
-3. Install dependencies using the `requirements.txt` file or the `requirements_m1.txt` file,:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
+    ```bash
+    pip install -r requirements.txt
+    ```
 
 ## Usage
 
@@ -118,24 +102,13 @@ img = generator.generate(
     input_image="/path/to/img.png"
 )
 
-# for inpainting :
-# mask should be single channel image with 2 dims [W, H]
-img = generator.generate(
-    "A Halloween bedroom",
-    num_steps=50,
-    unconditional_guidance_scale=7.5,
-    temperature=1,
-    batch_size=1,
-    input_image="/path/to/img.png",
-    input_mask="/path/to/mask.png"
-)
 
 Image.fromarray(img[0]).save("output.png")
 ```
 
 ### Using `text2image.py` from the git repo
 
-Assuming you have installed the required packages,
+Assuming you have installed the required packages, 
 you can generate images from a text prompt using:
 
 ```bash
@@ -151,7 +124,26 @@ python text2image.py --prompt="An astronaut riding a horse" --output="my_image.p
 
 Check out the `text2image.py` file for more options, including image size, number of steps, etc.
 
+## Example outputs 
+
+The following outputs have been generated using this implementation:
+
+1) *A epic and beautiful rococo werewolf drinking coffee, in a burning coffee shop. ultra-detailed. anime, pixiv, uhd 8k cryengine, octane render*
+
+![a](https://user-images.githubusercontent.com/1890549/190841598-3d0b9bd1-d679-4c8d-bd5e-b1e24397b5c8.png)
+
+
+2) *Spider-Gwen Gwen-Stacy Skyscraper Pink White Pink-White Spiderman Photo-realistic 4K*
+
+![a](https://user-images.githubusercontent.com/1890549/190841999-689c9c38-ece4-46a0-ad85-f459ec64c5b8.png)
+
+
+3) *A vision of paradise, Unreal Engine*
+
+![a](https://user-images.githubusercontent.com/1890549/190841886-239406ea-72cb-4570-8f4c-fcd074a7ad7f.png)
+
+
 ## References
 
-1. https://github.com/CompVis/stable-diffusion
-2. https://github.com/geohot/tinygrad/blob/master/examples/stable_diffusion.py
+1) https://github.com/CompVis/stable-diffusion
+2) https://github.com/geohot/tinygrad/blob/master/examples/stable_diffusion.py

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The easiest way to try it out is to use one of the Colab notebooks:
 
 - [GPU Colab](https://colab.research.google.com/drive/1zVTa4mLeM_w44WaFwl7utTaa6JcaH1zK)
 - [GPU Colab Img2Img](https://colab.research.google.com/drive/1gol0M611zXP6Zpggfri-fG8JDdpMEpsI?usp=sharing)
-- [GPU Colab Inpainting](https://colab.research.google.com/drive/15mQgITh3e9HQMNys0zR8JN4R2vp06d-N)
+- [GPU Colab Inpainting](https://colab.research.google.com/drive/1Bf-bNmAdtQhPcYNyC-guu0uTu9MYYfLu)
 - [GPU Colab + Mixed Precision](https://colab.research.google.com/drive/15mQgITh3e9HQMNys0zR8JN4R2vp06d-N)
   - ~10s generation time per image (512x512) on default Colab GPU without drop in quality
     ([source](https://twitter.com/fchollet/status/1571954014845308928))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The easiest way to try it out is to use one of the Colab notebooks:
 
 - [GPU Colab](https://colab.research.google.com/drive/1zVTa4mLeM_w44WaFwl7utTaa6JcaH1zK)
 - [GPU Colab Img2Img](https://colab.research.google.com/drive/1gol0M611zXP6Zpggfri-fG8JDdpMEpsI?usp=sharing)
-- [GPU Colab Inpainting](https://colab.research.google.com/drive/1Bf-bNmAdtQhPcYNyC-guu0uTu9MYYfLu)
+- [GPU Colab Inpainting+Text2Image+Image2Image+Mixed Precision](https://colab.research.google.com/drive/1Bf-bNmAdtQhPcYNyC-guu0uTu9MYYfLu)
 - [GPU Colab + Mixed Precision](https://colab.research.google.com/drive/15mQgITh3e9HQMNys0zR8JN4R2vp06d-N)
   - ~10s generation time per image (512x512) on default Colab GPU without drop in quality
     ([source](https://twitter.com/fchollet/status/1571954014845308928))

--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ The easiest way to try it out is to use one of the Colab notebooks:
 
 The following outputs have been generated using this implementation:
 
-1. _A dog with sunglasses, wearing comfy hat, looking at camera, highly detailed, ultra sharp, cinematic, 100mm lens, 8k resolution._
+Input Text: _A dog with sunglasses, wearing comfy hat, looking at camera, highly detailed, ultra sharp, cinematic, 100mm lens, 8k resolution._
+
+# Inpainting
 
 ![a](https://user-images.githubusercontent.com/44222184/194685370-e87970f7-dbf5-4d6d-a9d1-31594cdf751a.png)
+
+# Image2Image
+
+![a](https://user-images.githubusercontent.com/44222184/194686889-3d30bd3e-7bfb-4fe4-a6e1-c74bcf5b5944.png)
+
+# Text2Image
+
+![a](https://user-images.githubusercontent.com/44222184/194686712-cb15d191-39b9-4b17-a5c7-2671021ce5e5.png)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stable Diffusion in TensorFlow / Keras
 
-A Keras / Tensorflow implementation of Stable Diffusion. 
+A Keras / Tensorflow implementation of Stable Diffusion.
 
 The weights were ported from the original implementation.
 
@@ -8,9 +8,9 @@ The weights were ported from the original implementation.
 
 The easiest way to try it out is to use one of the Colab notebooks:
 
-
 - [GPU Colab](https://colab.research.google.com/drive/1zVTa4mLeM_w44WaFwl7utTaa6JcaH1zK)
 - [GPU Colab Img2Img](https://colab.research.google.com/drive/1gol0M611zXP6Zpggfri-fG8JDdpMEpsI?usp=sharing)
+- [GPU Colab Inpainting](https://colab.research.google.com/drive/15mQgITh3e9HQMNys0zR8JN4R2vp06d-N)
 - [GPU Colab + Mixed Precision](https://colab.research.google.com/drive/15mQgITh3e9HQMNys0zR8JN4R2vp06d-N)
   - ~10s generation time per image (512x512) on default Colab GPU without drop in quality
     ([source](https://twitter.com/fchollet/status/1571954014845308928))
@@ -18,8 +18,6 @@ The easiest way to try it out is to use one of the Colab notebooks:
   - Slower than GPU for single-image generation, faster for large batch of 8+ images
     ([source](https://twitter.com/fchollet/status/1572004717362028546)).
 - [GPU Colab with Gradio](https://colab.research.google.com/drive/1ANTUur1MF9DKNd5-BTWhbWa7xUBfCWyI)
-
-
 
 ## Installation
 
@@ -49,25 +47,25 @@ Install dependencies using the `requirements.txt` file or the `requirements_m1.t
 pip install -r requirements.txt
 ```
 
-#### Using a virtual environment with *virtualenv*
+#### Using a virtual environment with _virtualenv_
 
-1) Create your virtual environment for `python3`:
+1. Create your virtual environment for `python3`:
 
-    ```bash
-    python3 -m venv venv
-    ```
-   
-2) Activate your virtualenv:
+   ```bash
+   python3 -m venv venv
+   ```
 
-    ```bash
-    source venv/bin/activate
-    ```
+2. Activate your virtualenv:
 
-3) Install dependencies using the `requirements.txt` file or the `requirements_m1.txt` file,:
+   ```bash
+   source venv/bin/activate
+   ```
 
-    ```bash
-    pip install -r requirements.txt
-    ```
+3. Install dependencies using the `requirements.txt` file or the `requirements_m1.txt` file,:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ## Usage
 
@@ -102,13 +100,24 @@ img = generator.generate(
     input_image="/path/to/img.png"
 )
 
+# for inpainting :
+# mask should be single channel image with 2 dims [W, H]
+img = generator.generate(
+    "A Halloween bedroom",
+    num_steps=50,
+    unconditional_guidance_scale=7.5,
+    temperature=1,
+    batch_size=1,
+    input_image="/path/to/img.png",
+    input_mask="/path/to/mask.png"
+)
 
 Image.fromarray(img[0]).save("output.png")
 ```
 
 ### Using `text2image.py` from the git repo
 
-Assuming you have installed the required packages, 
+Assuming you have installed the required packages,
 you can generate images from a text prompt using:
 
 ```bash
@@ -124,26 +133,15 @@ python text2image.py --prompt="An astronaut riding a horse" --output="my_image.p
 
 Check out the `text2image.py` file for more options, including image size, number of steps, etc.
 
-## Example outputs 
+## Example outputs
 
 The following outputs have been generated using this implementation:
 
-1) *A epic and beautiful rococo werewolf drinking coffee, in a burning coffee shop. ultra-detailed. anime, pixiv, uhd 8k cryengine, octane render*
+1. _a man in very nice suit, wearing a tie, standing with a dragon, highly detailed, ultra sharp, 100mm lens, cinematic, 8k resolution._
 
-![a](https://user-images.githubusercontent.com/1890549/190841598-3d0b9bd1-d679-4c8d-bd5e-b1e24397b5c8.png)
-
-
-2) *Spider-Gwen Gwen-Stacy Skyscraper Pink White Pink-White Spiderman Photo-realistic 4K*
-
-![a](https://user-images.githubusercontent.com/1890549/190841999-689c9c38-ece4-46a0-ad85-f459ec64c5b8.png)
-
-
-3) *A vision of paradise, Unreal Engine*
-
-![a](https://user-images.githubusercontent.com/1890549/190841886-239406ea-72cb-4570-8f4c-fcd074a7ad7f.png)
-
+![a](https://user-images.githubusercontent.com/44222184/194581983-f7ce16a5-d558-4d82-bd84-ada466a16e17.png)
 
 ## References
 
-1) https://github.com/CompVis/stable-diffusion
-2) https://github.com/geohot/tinygrad/blob/master/examples/stable_diffusion.py
+1. https://github.com/CompVis/stable-diffusion
+2. https://github.com/geohot/tinygrad/blob/master/examples/stable_diffusion.py

--- a/stable_diffusion_tf/stable_diffusion.py
+++ b/stable_diffusion_tf/stable_diffusion.py
@@ -37,8 +37,6 @@ class StableDiffusion:
         if tf.keras.mixed_precision.global_policy().name == 'mixed_float16':
             self.dtype = tf.float16
 
-class StableDiffusionInpaint(StableDiffusion):
-
     def generate(
         self,
         prompt,
@@ -71,23 +69,17 @@ class StableDiffusionInpaint(StableDiffusion):
         if type(input_image) is str:
             input_image = Image.open(input_image)
             input_image = input_image.resize((self.img_width, self.img_height))
+            input_image_orgin = np.array(input_image)[... , :3]
 
-            # Keep a copy of original image for output merging
-            input_image_orgin = np.array(input_image, np.float32)[None, ..., :3]
-
-            input_image = (input_image_orgin / 255.0)*2 - 1
+            input_image = (input_image_orgin.astype("float") / 255.0)*2 - 1
             input_image = tf.cast(input_image, dtype)
 
         if type(input_mask) is str:
-            input_mask = Image.open(input_mask)
-
-            # Keep a copy of original mask for output merging
-            mask_origin = input_mask.resize((self.img_width, self.img_height))
-            mask_origin = np.array(mask_origin, np.float32)[None,...,None] / 255.0
-
-            latent_mask = input_mask.resize((self.img_width//8, self.img_height//8))
-            latent_mask = np.array(latent_mask, np.float32)[None,...,None]
-            latent_mask = 1 - (latent_mask / 255.0)
+            mask_origin = Image.open(input_mask)
+            
+            latent_mask = mask_origin.resize((self.img_width//8, self.img_height//8))
+            latent_mask = np.array(latent_mask)[None][...,None]
+            latent_mask = 1 - (latent_mask.astype("float") / 255.0)
             latent_mask = tf.cast(tf.repeat(latent_mask, batch_size , axis=0), dtype)
 
 
@@ -106,7 +98,7 @@ class StableDiffusionInpaint(StableDiffusion):
         )
 
         if input_image is not None:
-            timesteps = timesteps[:int(len(timesteps)*input_image_strength)]
+            timesteps = timesteps[: int(len(timesteps)*input_image_strength)]
 
         # Diffusion stage
         progbar = tqdm(list(enumerate(timesteps))[::-1])
@@ -126,20 +118,19 @@ class StableDiffusionInpaint(StableDiffusion):
             )
 
             if input_mask is not None:
-                # Add noise to input image at current timestep 
-                latent_orgin, alphas, alphas_prev = self.get_starting_parameters(
-                    timesteps, batch_size, seed , input_image=input_image, input_img_noise_t=timestep
-                )
-                # Merge noisy input image with predicted latent image
-                latent = latent_orgin * latent_mask + latent * (1- latent_mask)
+              latent_orgin, alphas, alphas_prev = self.get_starting_parameters(
+                  timesteps, batch_size, seed , input_image=input_image, input_img_noise_t=timestep
+              )
+              latent = latent_orgin * latent_mask + latent * (1- latent_mask)
 
         # Decoding stage
         decoded = self.decoder.predict_on_batch(latent)
         decoded = ((decoded + 1) / 2) * 255
 
         if input_mask is not None:
-            # Merge original image and inpainting output
-            decoded = input_image_orgin * (1-mask_origin) + np.array(decoded) * mask_origin
+          mask_origin = np.array(mask_origin)[...,None]
+          mask_origin =  (mask_origin.astype("float") / 255.0)
+          decoded = np.array(input_image_orgin) * (1-mask_origin) + np.array(decoded) * (mask_origin)
 
         return np.clip(decoded, 0, 255).astype("uint8")
 
@@ -168,7 +159,7 @@ class StableDiffusionInpaint(StableDiffusion):
         if input_image is None:
             latent = tf.random.normal((batch_size, n_h, n_w, 4), seed=seed)
         else:
-            latent = self.encoder(input_image)
+            latent = self.encoder(input_image[None])
             latent = tf.repeat(latent , batch_size , axis=0)
             latent = self.add_noise(latent, input_img_noise_t)
         return latent, alphas, alphas_prev

--- a/stable_diffusion_tf/stable_diffusion.py
+++ b/stable_diffusion_tf/stable_diffusion.py
@@ -65,7 +65,7 @@ class StableDiffusion:
         else:
           dtype = tf.float32
         
-
+        input_image_tensor = None
         if type(input_image) is str:
             input_image = Image.open(input_image)
             input_image = input_image.resize((self.img_width, self.img_height))

--- a/stable_diffusion_tf/stable_diffusion.py
+++ b/stable_diffusion_tf/stable_diffusion.py
@@ -60,10 +60,6 @@ class StableDiffusion:
         pos_ids = np.array(list(range(77)))[None].astype("int32")
         pos_ids = np.repeat(pos_ids, batch_size, axis=0)
         context = self.text_encoder.predict_on_batch([phrase, pos_ids])
-        if tf.keras.mixed_precision.global_policy().name == 'mixed_float16':
-          dtype = tf.half
-        else:
-          dtype = tf.float32
         
         input_image_tensor = None
         if type(input_image) is str:
@@ -71,7 +67,7 @@ class StableDiffusion:
             input_image = input_image.resize((self.img_width, self.img_height))
             input_image_array = np.array(input_image, dtype=np.float32)[None,...,:3]
 
-            input_image_tensor = tf.cast((input_image_array / 255.0) * 2 - 1, dtype)
+            input_image_tensor = tf.cast((input_image_array / 255.0) * 2 - 1, self.dtype)
 
         if type(input_mask) is str:
             input_mask = Image.open(input_mask)
@@ -82,7 +78,7 @@ class StableDiffusion:
             latent_mask = input_mask.resize((self.img_width//8, self.img_height//8))
             latent_mask = np.array(latent_mask, dtype=np.float32)[None,...,None]
             latent_mask = 1 - (latent_mask.astype("float") / 255.0)
-            latent_mask_tensor = tf.cast(tf.repeat(latent_mask, batch_size , axis=0), dtype)
+            latent_mask_tensor = tf.cast(tf.repeat(latent_mask, batch_size , axis=0), self.dtype)
 
 
         # Encode unconditional tokens (and their positions into an

--- a/stable_diffusion_tf/stable_diffusion.py
+++ b/stable_diffusion_tf/stable_diffusion.py
@@ -162,7 +162,7 @@ class StableDiffusion:
         if input_image is None:
             latent = tf.random.normal((batch_size, n_h, n_w, 4), seed=seed)
         else:
-            latent = self.encoder(input_image[None])
+            latent = self.encoder(input_image)
             latent = tf.repeat(latent , batch_size , axis=0)
             latent = self.add_noise(latent, input_img_noise_t)
         return latent, alphas, alphas_prev


### PR DESCRIPTION
New features:
1. Inpainting when both input_image and input_mask are provided. 
2. Mix precision for image2image and inpainting.

Bug fix:
1. In StableDiffusion.get_starting_parameters(),  noise should be added after tf.repeat(). Otherwise the same noise would be used for the whole batch.
2. Fixed tensor type error when doing mixed precision.  StableDiffusion now checks global policy dtype during initialization.