### PR TITLE
Add Support for Negative Prompts

### DIFF
--- a/img2img.py
+++ b/img2img.py
@@ -13,6 +13,12 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--negative-prompt",
+    type=str,
+    help="the negative prompt to use (if any)",
+)
+
+parser.add_argument(
     "--steps", 
     type=int, 
     default=50, 
@@ -45,6 +51,7 @@ generator = StableDiffusion(
 
 img = generator.generate(
     args.prompt,
+    negative_prompt=args.negative_prompt,
     num_steps=args.steps,
     unconditional_guidance_scale=7.5,
     temperature=1,

--- a/text2image.py
+++ b/text2image.py
@@ -14,6 +14,12 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--negative-prompt",
+    type=str,
+    help="the negative prompt to use (if any)",
+)
+
+parser.add_argument(
     "--output",
     type=str,
     nargs="?",
@@ -68,6 +74,7 @@ if args.mp:
 generator = StableDiffusion(img_height=args.H, img_width=args.W, jit_compile=False)
 img = generator.generate(
     args.prompt,
+    negative_prompt=args.negative_prompt,
     num_steps=args.steps,
     unconditional_guidance_scale=args.scale,
     temperature=1,


### PR DESCRIPTION
Implements support for an optional negative prompt that is used to initialize the unconditional context.
This is a feature that has been added to many sd forks, and has been requested in https://github.com/divamgupta/stable-diffusion-tensorflow/issues/48.

Example Colab:
https://colab.research.google.com/drive/1QsTve3BTzOUZDIAdzrzur487USloZvjX?usp=sharing
Note that `tf.random.set_seed(0)` in the colab examples is required to make seeds consistent across generations (see https://github.com/divamgupta/stable-diffusion-tensorflow/issues/25)

Also updates `text2image.py` and `img2img.py` to expose a `--negative-prompt` argument. Example usage:
```bash
python text2image.py --prompt="hilly landscape" --negative-prompt="grass"
```